### PR TITLE
feat(Api): billboards get api endpoint

### DIFF
--- a/server/api/billboards/__mocks__/genres-response-mock.ts
+++ b/server/api/billboards/__mocks__/genres-response-mock.ts
@@ -1,0 +1,80 @@
+export const movieGenresResponseMock = {
+  genres: [
+    {
+      "id": 28,
+      "name": "Action"
+    },
+    {
+      "id": 12,
+      "name": "Adventure"
+    },
+    {
+      "id": 16,
+      "name": "Animation"
+    },
+    {
+      "id": 35,
+      "name": "Comedy"
+    },
+    {
+      "id": 80,
+      "name": "Crime"
+    },
+    {
+      "id": 99,
+      "name": "Documentary"
+    },
+    {
+      "id": 18,
+      "name": "Drama"
+    },
+    {
+      "id": 10751,
+      "name": "Family"
+    },
+    {
+      "id": 14,
+      "name": "Fantasy"
+    },
+    {
+      "id": 36,
+      "name": "History"
+    },
+    {
+      "id": 27,
+      "name": "Horror"
+    },
+    {
+      "id": 10402,
+      "name": "Music"
+    },
+    {
+      "id": 9648,
+      "name": "Mystery"
+    },
+    {
+      "id": 10749,
+      "name": "Romance"
+    },
+    {
+      "id": 878,
+      "name": "Science Fiction"
+    },
+    {
+      "id": 10770,
+      "name": "TV Movie"
+    },
+    {
+      "id": 53,
+      "name": "Thriller"
+    },
+    {
+      "id": 10752,
+      "name": "War"
+    },
+    {
+      "id": 37,
+      "name": "Western"
+    }
+  ]
+}

--- a/server/api/billboards/__mocks__/now-playing-response-mock.ts
+++ b/server/api/billboards/__mocks__/now-playing-response-mock.ts
@@ -1,0 +1,29 @@
+import { TMDB_BASE_PAGINATED_RESPONSE_MOCK } from './tmdb-base-mocks';
+
+export const nowPlayingResponseMock = {
+  ...TMDB_BASE_PAGINATED_RESPONSE_MOCK,
+  "dates": {
+    "maximum": "2025-01-15",
+    "minimum": "2024-12-04"
+  },
+  "results": new Array(5).fill({
+    "adult": false,
+    "backdrop_path": "/euYIwmwkmz95mnXvufEmbL6ovhZ.jpg",
+    "genre_ids": [
+      28,
+      12,
+      18
+    ],
+    "id": 558449,
+    "original_language": "en",
+    "original_title": "Gladiator II",
+    "overview": "Years after witnessing the death of the revered hero Maximus at the hands of his uncle, Lucius is forced to enter the Colosseum after his home is conquered by the tyrannical Emperors who now lead Rome with an iron fist. With rage in his heart and the future of the Empire at stake, Lucius must look to his past to find strength and honor to return the glory of Rome to its people.",
+    "popularity": 4201.992,
+    "poster_path": "/2cxhvwyEwRlysAmRH4iodkvo0z5.jpg",
+    "release_date": "2024-11-05",
+    "title": "Gladiator II",
+    "video": false,
+    "vote_average": 6.776,
+    "vote_count": 2105
+  }),
+}

--- a/server/api/billboards/__mocks__/tmdb-base-mocks.ts
+++ b/server/api/billboards/__mocks__/tmdb-base-mocks.ts
@@ -1,0 +1,6 @@
+export const TMDB_BASE_PAGINATED_RESPONSE_MOCK = {
+  results: [],
+  page: 1,
+  total_pages: 194,
+  total_results: 3868
+}

--- a/server/api/billboards/__tests__/index.get.test.ts
+++ b/server/api/billboards/__tests__/index.get.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import getHandler from '@/server/api/billboards/index.get';
+import { nowPlayingResponseMock } from '@/server/api/billboards/__mocks__/now-playing-response-mock';
+import { movieGenresResponseMock } from '../__mocks__/genres-response-mock';
+
+const fetchMock = vi.fn((url) => {
+  if (url.includes('movie/now_playing')) return nowPlayingResponseMock
+
+  if (url.includes('genre/movie/list')) return movieGenresResponseMock
+
+  return null
+})
+
+vi.stubGlobal('$fetch', fetchMock);
+
+describe('Event handler: GET /billboards', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  })
+
+  it('should return an array of parsed movies', async () => {
+    const response = await getHandler({} as any);
+
+    expect(response).toEqual(expect.objectContaining({
+      movies: expect.arrayContaining([
+        expect.objectContaining({
+          title: expect.any(String),
+          genres: expect.arrayContaining([expect.any(String)]),
+          backdropPath: expect.any(String),
+          posterPath: expect.any(String),
+        })
+      ])
+    }));
+  })
+
+  it('should set genre as empty string if genre not found', async () => {
+    fetchMock.mockImplementation((url) => {
+      if (url.includes('movie/now_playing')) return nowPlayingResponseMock
+  
+      if (url.includes('genre/movie/list')) return { genres: [] }
+  
+      return null
+    })
+
+    const response = await getHandler({} as any);
+
+    expect(response).toEqual(expect.objectContaining({
+      movies: expect.arrayContaining([
+        expect.objectContaining({
+          genres: expect.arrayContaining(['']),
+        })
+      ])
+    }));
+  })
+})

--- a/server/api/billboards/index.get.ts
+++ b/server/api/billboards/index.get.ts
@@ -1,0 +1,43 @@
+import { objectToCamel } from 'ts-case-convert';
+import type {
+  ITMDBGenresApiResponse,
+  ITMDBNowPlayingApiResponse,
+} from '@/server/types/billboard';
+
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+
+  const { results } = await $fetch<ITMDBNowPlayingApiResponse>(
+    `${config.app.moviesDatabaseUrl}/movie/now_playing`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${config.app.moviesDatabaseAccessToken}`,
+      },
+    },
+  );
+
+  const { genres } = await $fetch<ITMDBGenresApiResponse>(
+    `${config.app.moviesDatabaseUrl}/genre/movie/list`,
+    {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${config.app.moviesDatabaseAccessToken}`,
+      },
+    },
+  );
+
+  const parsedMovies = results.map((movie) => ({
+    ...movie,
+    genres: movie.genre_ids.map(
+      (genreId) =>
+        genres.find((genre: any) => genre.id === genreId)?.name ?? '',
+    ),
+    backdrop_path: `https://image.tmdb.org/t/p/original/${movie.backdrop_path}`,
+    poster_path: `https://image.tmdb.org/t/p/w500/${movie.poster_path}`,
+  }));
+
+  return {
+    movies: objectToCamel(parsedMovies),
+  };
+});


### PR DESCRIPTION
This PR will add a new event handler to get current billboard:

API endpoint: `/api/billboards`

API response:
```
{
  movies: [
    {
      "adult": false,
      "backdropPath": "https://image.tmdb.org/t/p/original//euYIwmwkmz95mnXvufEmbL6ovhZ.jpg",
      "genreIds": [
        28,
        12,
        18
      ],
      "id": 558449,
      "originalLanguage": "en",
      "originalTitle": "Gladiator II",
      "overview": "Years after witnessing the death of the revered hero Maximus at the hands of his uncle, Lucius is forced to enter the Colosseum after his home is conquered by the tyrannical Emperors who now lead Rome with an iron fist. With rage in his heart and the future of the Empire at stake, Lucius must look to his past to find strength and honor to return the glory of Rome to its people.",
      "popularity": 4201.992,
      "posterPath": "https://image.tmdb.org/t/p/w500//2cxhvwyEwRlysAmRH4iodkvo0z5.jpg",
      "releaseDate": "2024-11-05",
      "title": "Gladiator II",
      "video": false,
      "voteAverage": 6.776,
      "voteCount": 2105,
      "genres": [
        "Action",
        "Adventure",
        "Drama"
      ]
    }
  ]
}
```